### PR TITLE
fix: remove functions config to resolve Vercel serverless function pattern error

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -4,11 +4,6 @@
   "devCommand": "npm run dev",
   "installCommand": "npm install",
   "framework": "astro",
-  "functions": {
-    "src/pages/api/contact.js": {
-      "maxDuration": 10
-    }
-  },
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION

This pull request updates the `vercel.json` configuration file by removing the custom function configuration for the `src/pages/api/contact.js` endpoint.

Configuration changes:

- Removed functions configuration from vercel.json 
> NOTE: Astro framework handles API routes automatically on Vercel